### PR TITLE
Add support for Roboclaw PID commands and roboclaw initialization

### DIFF
--- a/src_servo/Makefile
+++ b/src_servo/Makefile
@@ -12,6 +12,7 @@
 #++	May 19,	2022	<RNS> Added support for rc_utils unit test
 #++	May 19,	2022	<RNS> Fixed all unit tests for *.c files with unit _TEST_
 #++	May 27,	2022	<RNS> Added support for servo_time unit test
+#++	May 27,	2022	<RNS> Added support for test_cop
 ############################################################################
 
 CC			=	gcc -I$(MLS_LIB_DIR)
@@ -45,10 +46,16 @@ RCUTILS_OBJECTS	=								\
 
 servo_test_tty:	CFLAGS	+=
 servo_test_tty: 	$(SERVO_OBJECTS)	$(OBJECT_DIR)servo_test_tty.o
-
 	$(CC) $(CFLAGS) -o servo_test_tty				\
 					$(SERVO_OBJECTS)				\
 					$(OBJECT_DIR)servo_test_tty.o	\
+					-lm
+
+test_cop: 	CFLAGS	+=
+test_cop: 	$(SERVO_OBJECTS) $(OBJECT_DIR)test_cop.o
+	$(CC) $(CFLAGS) -o test_cop					\
+					$(SERVO_OBJECTS)			\
+					$(OBJECT_DIR)test_cop.o	\
 					-lm
 
 servo_test: 	CFLAGS	+=	-D_TEST_SERVO_MOUNT_
@@ -56,7 +63,6 @@ servo_test: 	$(SERVO_OBJECTS)
 	$(CC) $(CFLAGS) -o servo_test 				\
 					$(SERVO_OBJECTS)			\
 					-lm
-
 
 test_cfg: 	CFLAGS	+=	-D_TEST_SERVO_MOUNT_CFG_
 test_cfg: 	$(TESTCFG_OBJECTS)
@@ -97,6 +103,9 @@ $(OBJECT_DIR)servo_mount_cfg.o: servo_mount_cfg.c servo_mount_cfg.h servo_time.h
 
 $(OBJECT_DIR)servo_mount.o:		servo_mount.c servo_mount.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
 	$(CC) $(CFLAGS) -c servo_mount.c -o $(OBJECT_DIR)servo_mount.o
+
+$(OBJECT_DIR)test_cop.o:		test_cop.c servo_mount.c servo_mount.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
+	$(CC) $(CFLAGS) -c test_cop.c -o $(OBJECT_DIR)test_cop.o
 
 $(OBJECT_DIR)servo_test_tty.o:		servo_test_tty.c servo_mount.c servo_mount.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
 	$(CC) $(CFLAGS) -c servo_test_tty.c -o $(OBJECT_DIR)servo_test_tty.o

--- a/src_servo/servo_mount.cfg
+++ b/src_servo/servo_mount.cfg
@@ -50,7 +50,7 @@ RA_MAIN_GEAR:	360.0
 
 # Number of encoder transition with quadrature / motor revolution
 #RA_ENCODER:		2000.0
-RA_ENCODER:		400.0
+RA_ENCODER:		800.0
 
 
 # Maximum velocity during slew in arcsec/sec
@@ -73,10 +73,10 @@ RA_SLEW_VEL:	7200.0
 # Filter parameters for motor controllers
 # DO NOT CHANGE!!!
 RA_SI_CON:		0
-RA_KP_CON:		60
-RA_KI_CON:		30
-RA_KD_CON:		130
-RA_IL_CON:		600
+RA_KP_CON:		54.0
+RA_KI_CON:		2.0
+RA_KD_CON:		220.0
+RA_IL_CON:		540.0
 
 #
 # physical parameters for the DEC axis
@@ -100,7 +100,7 @@ DEC_MAIN_GEAR:   360.0
 
 # Number of encoder transition with quadrature / motor revolution
 #DEC_ENCODER:     2000.0
-DEC_ENCODER:     400.0
+DEC_ENCODER:     800.0
 
 
 # Maximum velocity during slew in arcsec/sec
@@ -122,10 +122,10 @@ DEC_SLEW_VEL:        8000.0
 # Filter parameters for motor controllers
 # DO NOT CHANGE!!!
 DEC_SI_CON:      0
-DEC_KP_CON:      60
-DEC_KI_CON:      30
-DEC_KD_CON:      130
-DEC_IL_CON:      600
+DEC_KP_CON:      54.0
+DEC_KI_CON:      2.0
+DEC_KD_CON:      220.0
+DEC_IL_CON:      540.0
 
 # The declination assumed to be the park position and
 # will also be the end position after the session.

--- a/src_servo/servo_mount.h
+++ b/src_servo/servo_mount.h
@@ -32,6 +32,7 @@
 //*	May 22,	2022	<RNS> added _axis_ to functions that worked a single axis
 //*	May 22,	2022	<RNS> added move_axis_by_vel for the ASCOM guiding functionality
 //*	May 22,	2022	<RNS> General cleanup to get data/control flow aligned with ASCOM
+//* Jun  6,	2022	<RNS> regenerated *all* function declarations with cproto
 //****************************************************************************
 
 #ifndef _SERVO_MOUNT_H_
@@ -57,40 +58,38 @@ typedef enum
 	extern "C" {
 #endif
 
-int			Servo_set_comm_port(char com[], int baud);
-void		Servo_get_park_coordins(double *ha, double *dec);
-void		Servo_get_standby_coordins(double *ha, double *dec);
-void		Servo_get_sync_coordins(double *ra, double *dec);
-void		Servo_set_time_ratio(double ratio);
-double		Servo_get_time_ratio(void);
-bool		Servo_unpark(void);
-bool		Servo_get_park_state(void);
-int8_t		Servo_get_pier_side(void); 
-int			Servo_scale_acc(int32_t percentRa, int32_t percentDec);
-int			Servo_scale_vel(int32_t percentRa, int32_t percentDec);
-bool		Servo_ignore_horizon(bool state);
-int			Servo_reset_motor(uint8_t motor);
-void		Servo_step_to_pos(int32_t raStep, int32_t decStep, double *ra, double *dec);
-//void		Servo_pos_to_step(double ra, double dec, int32_t *raStep, int32_t *decStep);
-void		Servo_get_pos(double *ra, double *dec);
-void		Servo_set_pos(double ra, double dec);
-void		Servo_set_static_pos(double ha, double dec);
-int32_t		Servo_get_axis_step_track(uint8_t motor);
-int			Servo_set_axis_step_track(uint8_t motor, int32_t tracking);
-int			Servo_start_axis_tracking(uint8_t motor);
-int			Servo_stop_axis_tracking(uint8_t motor);
-int 		Servo_move_axis_by_vel(uint8_t motor, double vel);
-int			Servo_init(const char *mountCfgFile, const char *localCfgFile);
-TYPE_MOVE	Servo_state(void);
-//int       	Servo_move_step_track(int32_t raStep, int32_t decStep);
-//int			Servo_move_step(int32_t raStep, int32_t decStep, bool buffered);
-//void		Servo_calc_flip_coordins(double *ra, double *dec, double *direction, int8_t *side);
-void		Servo_stop_all(void);
-//bool		Servo_calc_optimal_path(double startRa, double startDec, double lst, double endRa, double endDec, double *raDirection, double *decDirection);
-int 		Servo_move_spiral(double raMove, double decMove, int loop);
-int			Servo_move_to_coordins(double gotoRa, double gotoDec, double lat, double lon);
-int			Servo_move_to_static(double parkHA, double parkDec);
-int 		Servo_move_to_park(void);
+// servo_mount.c 
+int Servo_set_comm_port(char com[], int baud);
+void Servo_get_park_coordins(double *ha, double *dec);
+void Servo_get_standby_coordins(double *ha, double *dec);
+void Servo_get_sync_coordins(double *ra, double *dec);
+void Servo_set_time_ratio(double ratio);
+double Servo_get_time_ratio(void);
+bool Servo_unpark(void);
+bool Servo_get_park_state(void);
+int8_t Servo_get_pier_side(void);
+int Servo_scale_acc(int32_t percentRa, int32_t percentDec);
+int Servo_scale_vel(int32_t percentRa, int32_t percentDec);
+bool Servo_ignore_horizon(bool state);
+int Servo_reset_motor(uint8_t motor);
+void Servo_step_to_pos(int32_t raStep, int32_t decStep, double *ra, double *dec);
+void Servo_get_pos(double *ra, double *dec);
+void Servo_set_pos(double ra, double dec);
+void Servo_set_static_pos(double ha, double dec);
+int32_t Servo_get_axis_step_track(uint8_t motor);
+int Servo_set_axis_step_track(uint8_t motor, int32_t tracking);
+int Servo_start_axis_tracking(uint8_t motor);
+int Servo_stop_axis_tracking(uint8_t motor);
+int Servo_move_axis_by_vel(uint8_t motor, double vel);
+int Servo_init(const char *mountCfgFile, const char *localCfgFile);
+TYPE_MOVE Servo_state(void);
+void Servo_stop_all(void);
+double Servo_calc_short_vector(double begin, double end, double max);
+bool Servo_calc_optimal_path(double startRa, double startDec, double lst, double endRa, double endDec, double *raDirection, double *decDirection);
+int Servo_move_spiral(double raMove, double decMove, int loop);
+int Servo_move_to_coordins(double gotoRa, double gotoDec, double lat, double lon);
+int Servo_move_to_static(double parkHA, double parkDec);
+int Servo_move_to_park(void);
 
 #ifdef __cplusplus
 }

--- a/src_servo/servo_mount_cfg.c
+++ b/src_servo/servo_mount_cfg.c
@@ -42,6 +42,7 @@
 //*	May 23,	2022	<MLS> Modified config processing so that error strings are returned
 //*	May 26,	2022	<MLS> Added PrintMountConfiguration();
 //*	May 26,	2022	<MLS> Updated test code to print out config
+//*	Jun 12,	2022	<RNS> Added RC PID support and moved PIDL fields to float
 //****************************************************************************
 
 #include <stdio.h>
@@ -376,52 +377,52 @@ int				dummy;
 
 		case RA_KP_CON:
 			gMountConfigArray[RA_KP_CON].found	=	true;
-			ra->kp								=	atoi(argument);
+			ra->kp								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, ra->kp);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, ra->kp);
-				sprintf(cfgErrorString2,	"Usage:  %s  60", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, ra->kp);
+				sprintf(cfgErrorString2,	"Usage:  %s  60.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case RA_KI_CON:
 			gMountConfigArray[RA_KI_CON].found	=	true;
-			ra->ki								=	atoi(argument);
+			ra->ki								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, ra->ki);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, ra->ki);
-				sprintf(cfgErrorString2,	"Usage:  %s  30", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, ra->ki);
+				sprintf(cfgErrorString2,	"Usage:  %s  30.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case RA_KD_CON:
 			gMountConfigArray[RA_KD_CON].found	=	true;
-			ra->kd								=	atoi(argument);
+			ra->kd								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, ra->kd);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, ra->kd);
-				sprintf(cfgErrorString2,	"Usage:  %s  300", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, ra->kd);
+				sprintf(cfgErrorString2,	"Usage:  %s  300.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case RA_IL_CON:
 			gMountConfigArray[RA_IL_CON].found	=	true;
-			ra->il								=	atoi(argument);
+			ra->il								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, ra->il);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, ra->il);
-				sprintf(cfgErrorString2,	"Usage:  %s  130", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, ra->il);
+				sprintf(cfgErrorString2,	"Usage:  %s  130.0", token);
 				configLineOK	=	false;
 			}
 			break;
@@ -532,53 +533,53 @@ int				dummy;
 
 		case DEC_KP_CON:
 			gMountConfigArray[DEC_KP_CON].found	=	true;
-			dec->kp								=	atoi(argument);
+			dec->kp								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, dec->kp);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, dec->kp);
-				sprintf(cfgErrorString2,	"Usage:  %s  60", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, dec->kp);
+				sprintf(cfgErrorString2,	"Usage:  %s  60.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case DEC_KI_CON:
 			gMountConfigArray[DEC_KI_CON].found	=	true;
-			dec->ki								=	atoi(argument);
+			dec->ki								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, dec->ki);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, dec->ki);
-				sprintf(cfgErrorString2,	"Usage:  %s  60", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, dec->ki);
+				sprintf(cfgErrorString2,	"Usage:  %s  60.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case DEC_KD_CON:
 			gMountConfigArray[DEC_KD_CON].found	=	true;
-			dec->kd								=	atoi(argument);
+			dec->kd								=	atof(argument);
 
 		//	printf("%-15.15s = %-15d  \n", token, dec->kd);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, dec->kd);
-				sprintf(cfgErrorString2,	"Usage:  %s  300", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, dec->kd);
+				sprintf(cfgErrorString2,	"Usage:  %s  300.0", token);
 				configLineOK	=	false;
 			}
 			break;
 
 		case DEC_IL_CON:
 			gMountConfigArray[DEC_IL_CON].found	=	true;
-			dec->il								=	atoi(argument);
+			dec->il								=	atof(argument);
 		//	printf("%-15.15s = %-15d  \n", token, dec->il);
 
 			if (!isdigit(argument[0]))
 			{
-				sprintf(cfgErrorString1,	"Invalid %s field '%d'", token, dec->il);
-				sprintf(cfgErrorString2,	"Usage:  %s  130", token);
+				sprintf(cfgErrorString1,	"Invalid %s field '%f'", token, dec->il);
+				sprintf(cfgErrorString2,	"Usage:  %s  130.0", token);
 				configLineOK	=	false;
 			}
 			break;

--- a/src_servo/servo_mount_cfg.h
+++ b/src_servo/servo_mount_cfg.h
@@ -28,6 +28,7 @@
 //*	May 19,	2022	<RNS> Change all refs of 'scope' to 'mount', including filenames
 //*	May 20,	2022	<RNS> added to flipWin and offTarget to TYPE_MOUNT_CONFIG
 //*	May 22,	2022	<RNS> Changed .pos from unsigned to signed
+//*	Jun 12,	2022	<RNS> Changed PIDL fields from integer to double 
 //****************************************************************************
 
 #ifndef _SERVO_MOUNT_CFG_H_
@@ -127,10 +128,10 @@ typedef struct
 	uint32_t	adj;
 	uint32_t	slew;
 	uint8_t		si;
-	uint16_t	kp;
-	uint16_t	ki;
-	uint16_t	kd;
-	uint16_t	il;
+	double		kp;
+	double		ki;
+	double		kd;
+	double		il;
 	uint16_t	status;
 	uint8_t		cmdQueue;
 	int32_t		track;

--- a/src_servo/servo_rc_cmds.h
+++ b/src_servo/servo_rc_cmds.h
@@ -26,6 +26,7 @@
 //*	Apr 27,	2022	<RNS> Update spreadsheet to add yet more commands
 //*	May  6,	2022	<RNS> changed filename to servo_rc_cmds, fixed #defines
 //*	May  6,	2022	<RNS> Fixed corrupted spreadsheet data
+//*	Jun  6,	2022	<RNS> Fixed naming convetion from READ to GET for PID cmds
 //*****************************************************************************
 #ifndef _SERVO_RC_CMDS_H_
 #define _SERVO_RC_CMDS_H_
@@ -65,16 +66,16 @@ enum
 	GETBUFFERS				=	18,
 	GETPWMS					=	19,
 	GETCURRENTS				=	20,
-	READM1VELPID			=	21,
-	READM2VELPID			=	22,
+	GETM1VELPID				=	21,
+	GETM2VELPID				=	22,
 	SETMAINVOLTAGES			=	23,
 	SETLOGICVOLTAGES		=	24,
 	GETMAINVOLTSETTING		=	25,
 	GETLOGICVOLTSETTING		=	26,
 	SETM1POSPID				=	27,
 	SETM2POSPID				=	28,
-	READM1POSPID			=	29,
-	READM2POSPID			=	30,
+	GETM1POSPID				=	29,
+	GETM2POSPID				=	30,
 	M1SPEEDACCELDECELPOS	=	31,
 	M2SPEEDACCELDECELPOS	=	32,
 	MIXEDSPEEDACCELDECELPOS	=	33,

--- a/src_servo/servo_rc_utils.h
+++ b/src_servo/servo_rc_utils.h
@@ -30,7 +30,9 @@
 //*	May  8,	2022	<RNS> fadd a & va suffixes to the move_by functions
 //*	May 21,	2022	<RNS> added addr arg to RC_ MC cmds for multi-RC support
 //*	May 22,	2022	<RNS> corrected some signness for pos and vel args
-//*	May 22,	2022	<RNS> addded buffered capability to move_by_vela() 
+//*	May 22,	2022	<RNS> added buffered capability to move_by_vela() 
+//*	Jun 12	2022	<RNS> Updated functions list using cproto
+//*	Jun 13	2022	<RNS> Converted all PID function to use float for PID args
 //****************************************************************************
 //#include "servo_rc_utils.h"
 
@@ -74,19 +76,25 @@
 // Speed Error Limit Warning 0x01000000
 // Position Error Limit Warning 0x02000000
 
-void	str_to_upper(char *in);
-int		RC_converse(uint8_t *cmdBuf, size_t cmdLen, uint8_t *retBuf, size_t retLen);
-int		RC_get_curr_pos(uint8_t addr, uint8_t motor, int32_t *pos);
-int		RC_get_curr_velocity(uint8_t addr, uint8_t motor, int32_t *vel);
-int		RC_set_home(uint8_t addr, uint8_t motor);
-int		RC_get_status(uint8_t addr, uint32_t *rcStatus);
-int		RC_check_queue(uint8_t addr, uint8_t *raDepth, uint8_t *decDepth);
-int		RC_set_default_acc(uint8_t addr, uint8_t motor, uint32_t acc);
-int		RC_stop(uint8_t addr, uint8_t motor);
-double	RC_calc_move_time(int32_t pos0, int32_t pos1, uint32_t vel, uint32_t acc);
-int		RC_move_by_posv(uint8_t addr, uint8_t motor, int32_t pos, uint32_t vel, bool buffered);
-int		RC_move_by_posva(uint8_t addr, uint8_t motor, int32_t pos, uint32_t vel, uint32_t acc, bool buffered);
-int		RC_move_by_vela(uint8_t addr, uint8_t motor, int32_t vel, uint32_t acc, bool buffered);
-int		RC_move_by_vel_raw(uint8_t addr, uint8_t motor, int32_t vel);
+int RC_converse(uint8_t *cmdBuf, size_t cmdLen, uint8_t *retBuf, size_t retLen);
+int RC_get_curr_pos(uint8_t addr, uint8_t motor, int32_t *pos);
+int RC_get_curr_velocity(uint8_t addr, uint8_t motor, int32_t *vel);
+int RC_set_home(uint8_t addr, uint8_t motor);
+int RC_get_status(uint8_t addr, uint32_t *rcStatus);
+int RC_check_queue(uint8_t addr, uint8_t *raDepth, uint8_t *decDepth);
+int RC_set_default_acc(uint8_t addr, uint8_t motor, uint32_t acc);
+int RC_write_settings(uint8_t addr);
+int RC_read_settings(uint8_t addr, uint32_t *rcStatus);
+int RC_get_pos_pid(uint8_t addr, uint8_t motor, double *propo, double *integ, double *deriv, uint32_t *iMax, uint32_t *deadZ, int32_t *minP, int32_t *maxP);
+int RC_set_pos_pid(uint8_t addr, uint8_t motor, double propo, double integ, double deriv, uint32_t iMax, uint32_t deadZ, int32_t minP, int32_t maxP);
+int RC_get_vel_pid(uint8_t addr, uint8_t motor, double *propo, double *integ, double *deriv, uint32_t *qpps);
+int RC_set_vel_pid(uint8_t addr, uint8_t motor, double propo, double integ, double deriv, uint32_t qpps);
+int RC_restore_defaults(uint8_t addr);
+int RC_stop(uint8_t addr, uint8_t motor);
+double RC_calc_move_time(int32_t pos0, int32_t pos1, uint32_t vel, uint32_t acc);
+int RC_move_by_posv(uint8_t addr, uint8_t motor, int32_t pos, uint32_t vel, bool buffered);
+int RC_move_by_posva(uint8_t addr, uint8_t motor, int32_t pos, uint32_t vel, uint32_t acc, bool buffered);
+int RC_move_by_vela(uint8_t addr, uint8_t motor, int32_t vel, uint32_t acc, bool buffered);
+int RC_move_by_vel_raw(uint8_t addr, uint8_t motor, int32_t vel);
 
 #endif // _SERVO_RC_UTILS_H_

--- a/src_servo/servo_std_defs.h
+++ b/src_servo/servo_std_defs.h
@@ -31,6 +31,7 @@
 //*	May 11,	2022	<MLS> Changed constant RA to SERVO_RA_AXIS
 //*	May 11,	2022	<MLS> Changed constant DEC to SERVO_DEC_AXIS
 //*	May 14,	2022	<MLS> Removed degToRads/radToDegs
+//*	Jun 12,	2022	<RNS> Renamed ARCSEC_PER_SEC to SID_RATE_ARCSECS
 //*****************************************************************************
 //#include	"servo_std_defs.h"
 
@@ -60,7 +61,7 @@
 #define	kWEST			'w'
 #define	kNONE			'n'
 
-#define	kARCSEC_PER_SEC	15.04106864
+#define	kSID_RATE_ARCSECS	15.04106864
 
 #define	SERVO_RA_AXIS	(uint8_t)0
 #define	SERVO_DEC_AXIS	(uint8_t)1

--- a/src_servo/servo_time.c
+++ b/src_servo/servo_time.c
@@ -550,8 +550,8 @@ double latRad	=	RADIANS(lat);
 		return(kERROR);
 	}
 	// the magic rate formulas for both axes in arcsec/sec
-	*rateAlt	=	cos(latRad) * sin(azi) * kARCSEC_PER_SEC;
-	*rateAzi	=	(sin(latRad) * sin(zenith) - (cos(latRad) * cos(zenith) * cos(azi))) / sin(zenith) * kARCSEC_PER_SEC;
+	*rateAlt	=	cos(latRad) * sin(azi) * kSID_RATE_ARCSECS;
+	*rateAzi	=	(sin(latRad) * sin(zenith) - (cos(latRad) * cos(zenith) * cos(azi))) / sin(zenith) * kSID_RATE_ARCSECS;
 
 	// TODO: integrate the forumla for blind spot region where azi rate exceeds axis max vel
 	// this should be an return error condition
@@ -571,7 +571,7 @@ double rotRate;
 
 	// convert lat to radians and calc rotation rate
 	latRad	=	RADIANS(lat);
-	rotRate	=	kARCSEC_PER_SEC * cos(latRad) * cos(azi) / cos(alt);
+	rotRate	=	kSID_RATE_ARCSECS * cos(latRad) * cos(azi) / cos(alt);
 
 	return(rotRate);
 } // calc_field_rotation()

--- a/src_servo/test_cop.c
+++ b/src_servo/test_cop.c
@@ -1,0 +1,127 @@
+
+#include <stdio.h>
+#include <math.h>
+#include <stdint.h>
+#include <math.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "servo_std_defs.h"
+#include "servo_mc_core.h"
+#include "servo_time.h"
+#include "servo_rc_utils.h"
+#include "servo_mount_cfg.h"
+#include "servo_mount.h"
+
+// Minimum globals needed for the test program, copied from servo_mount.c 
+extern TYPE_MOUNT_CONFIG gMountConfig;
+static char gDebugInfoCOP[] = "00000";
+
+
+int main(int argc, char *argv[])
+{
+	double startRa, startDec, endRa, endDec;
+	double lst;
+	double raVec, decVec;
+	char mount;
+	bool flip;
+	char buf[128];
+	FILE *inFile;
+
+	printf("TEST Servo_calc_optimal_path() program 1.0 - Flip Window = %lf\n\n", gMountConfig.flipWin);
+	// printf("Input-> Mount LST startRa startDec endRa endDec\n");
+
+    // Init the data structure 
+    Servo_init(NULL, NULL);
+
+	if (argc != 2)
+	{
+		printf("Error! Must specify input file\n");
+		exit(-1);
+	}
+
+	inFile = fopen(argv[1], "r");
+
+	fgets(buf, 128, inFile);
+	sscanf(buf, "%c %lf %lf %lf %lf %lf", &mount, &lst, &startRa, &startDec, &endRa, &endDec);
+
+	switch (mount)
+	{
+	case 'G':
+	case 'g':
+		gMountConfig.mount = kGERMAN;
+		break;
+
+	case 'F':
+	case 'f':
+		gMountConfig.mount = kFORK;
+		break;
+
+	case '#':
+	case 'Q':
+	case 'q':
+		// Do nothing, let the while loop handle it
+		break;
+
+	default:
+		printf("Error!  Input line format *'%s'* unsupported\n", buf);
+		fclose(inFile);
+		exit(-1);
+		break;
+	}
+
+	while (mount != 'Q' || mount != 'q')
+	{
+
+		switch (mount)
+		{
+		case '#':
+			// Comment line, just print it
+			printf("%s", buf);
+			break;
+
+		case 'G':
+		case 'g':
+			// GEM mount
+			printf("Mount:%c LST:%.2lf sRA:%.2lf sDec:%.2lf eRA:%.2lf eDec:%.2lf\n", mount, lst, startRa, startDec, endRa, endDec);
+			flip = Servo_calc_optimal_path(startRa, startDec, lst, endRa, endDec, &raVec, &decVec);
+			printf("-> result move Flip= %d raVec= %.2lf decVec= %.2lf  %s\n\n", flip, raVec, decVec, gDebugInfoCOP);
+			break;
+
+		case 'F':
+		case 'f':
+			// FORK mount
+			printf("Mount:%c LST:%.2lf sRA:%.2lf sDec:%.2lf eRA:%.2lf eDec:%.2lf\n", mount, lst, startRa, startDec, endRa, endDec);
+			flip = Servo_calc_optimal_path(startRa, startDec, lst, endRa, endDec, &raVec, &decVec);
+			printf("-> result move Flip= %d raVec= %.2lf decVec= %.2lf  %s\n\n", flip, raVec, decVec, gDebugInfoCOP);
+			break;
+
+		case 'Q':
+		case 'q':
+			fclose(inFile);
+			exit(0);
+			break;
+
+		default:
+			printf("Error!  Input line format *'%s'* unsupported\n", buf);
+			fclose(inFile);
+			exit(-1);
+			break;
+		} // of switch
+
+		// Get the next line from input file and parse
+		fgets(buf, 128, inFile);
+		if (feof(inFile))
+		{
+			exit(0);
+		}
+
+		sscanf(buf, "%c %lf %lf %lf %lf %lf", &mount, &lst, &startRa, &startDec, &endRa, &endDec);
+
+	} // of while
+
+	// Should never get here, but just in case
+	fclose(inFile);
+	exit(0);
+}

--- a/src_servo/test_cop_input.txt
+++ b/src_servo/test_cop_input.txt
@@ -1,0 +1,40 @@
+#************************************
+# GEM MOUNT TESTING
+#************************************
+# GEM1 westward move east of LST 2
+# Move is from -4HA to -2HA - wORKS!
+G 2 6 45 4 80
+# GEM2 westward move across meridan and 0/24  LST 2 
+# Move is from -4HA to +4HA - WORKS!
+G 2 6 45 22 15
+# GEM3 westward move across meridan and 0/24  LST 2 but within meridian window
+# Move is -4HA to +1HA - WORKS!
+G 2 6 45 1 15
+# GEM4 eastward move across meridan LST 10 
+# Move is +2HA to -4HA - WORKS!
+G 10 8 60 14 20
+# GEM5 shoot under the pole LST 10
+# Move is +2HA to -10HA - WORKS!
+G 10 8 60 20 80
+#************************************
+# FORK MOUNT TESTING
+#************************************
+# FORK1 westward move east of LST 2
+# Move is -4HA to +2HA - WORKS!
+F 2 6 45 4 80
+# FORK2 westward move across meridian  of LST 2 
+# Move is -4HA to -1HA - WORKS! - but may be better not TTP, good for testing
+F 2 6 45 1 80
+# FORK3 westward move across meridian and past meridian window with LST 3
+# Move is -3HA to +2HA - WORKS! - but may be better not TTP, good for testing
+F 3 6 45 1 80
+# FORK4 westward move across meridian and past meridian window and 0/24 with LST 2 
+# Move is -4HA to +4HA - WORKS! - but may be better not TTP, good for testing
+F 2 6 45 22 15
+# FORK5 eastward move across meridan LST 10 - WORKS
+# Move is +2HA to -4HA - WORKS! - but may be better not TTP, good for testing
+F 10 8 60 14 20
+# FORK6 shoot under the pole LST 10 - ERROR should have gone TTP
+# Move is -2HA to +10HA - WORKS! - but may be better not TTP, good for testing
+F 10 8 60 20 80
+Q


### PR DESCRIPTION
Reads all motor configs from the servo_mount.cfg file for the PID value and update servo_init() to handle support of both RC position PID and velocity PID.  Servo_rc_utils now supports saving RC board settings into EEPROM. 