### PR TITLE
Fixed E1013 error and add write settings for RC

### DIFF
--- a/src_servo/Makefile
+++ b/src_servo/Makefile
@@ -22,6 +22,7 @@
 #++	Jul  2,	2022	<RNS> Enabled gdb support in CFLAGS (-g)
 #++	Jul 20,	2022	<RNS> Support servo_move and servo_pos_step test progs
 #++	Nov  4,	2022	<RNS> Added missing servo_motion dependencies to existing
+#++	Nov 12,	2022	<RNS> Added servo_write_settings support
 ############################################################################
 
 CC			=	gcc -I$(MLS_LIB_DIR)
@@ -87,7 +88,14 @@ servo_move: 	$(SERVO_OBJECTS)	$(OBJECT_DIR)servo_move.o
 					$(SERVO_OBJECTS)				\
 					$(OBJECT_DIR)servo_move.o	\
 					-lm					
-	
+
+servo_write_settings:		CFLAGS	+=
+servo_write_settings: 	$(SERVO_OBJECTS)	$(OBJECT_DIR)servo_write_settings.o
+	$(CC) $(CFLAGS) -o servo_write_settings				\
+					$(SERVO_OBJECTS)				\
+					$(OBJECT_DIR)servo_write_settings.o	\
+					-lm		
+
 servo_pos_step:		CFLAGS	+=
 servo_pos_step: 	$(SERVO_OBJECTS)	$(OBJECT_DIR)servo_pos_step.o
 	$(CC) $(CFLAGS) -o servo_pos_step			\
@@ -184,6 +192,9 @@ $(OBJECT_DIR)servo_test_tty.o:		servo_test_tty.c servo_mount.h servo_motion.h se
 $(OBJECT_DIR)servo_move.o:		servo_move.c servo_mount.h servo_motion.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
 	$(CC) $(CFLAGS) -c servo_move.c -o $(OBJECT_DIR)servo_move.o	
 
+$(OBJECT_DIR)servo_write_settings.o:		servo_write_settings.c servo_mount.h servo_motion.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
+	$(CC) $(CFLAGS) -c servo_write_settings.c -o $(OBJECT_DIR)servo_write_settings.o	
+	
 $(OBJECT_DIR)servo_pos_step.o:		servo_pos_step.c servo_mount.h servo_motion.h servo_rc_utils.h servo_rc_cmds.h servo_time.h servo_mc_core.h servo_std_defs.h
 	$(CC) $(CFLAGS) -c servo_pos_step.c -o $(OBJECT_DIR)servo_pos_step.o	
 

--- a/src_servo/servo_motion.h
+++ b/src_servo/servo_motion.h
@@ -27,6 +27,7 @@
 //*	Oct 28,	2022	<RNS> Updated via cproto
 //*	Nov  1,	2022	<RNS> Updated via cproto
 //*	Nov  9,	2022	<RNS> Updated via cproto
+//*	Nov 12,	2022	<RNS> Updated via cproto
 //****************************************************************************
 //#include	"servo_motion.h"
 
@@ -59,10 +60,11 @@ int Motion_set_axis_absZero(uint8_t axis, int32_t count);
 int Motion_get_axis_absZero(uint8_t axis, int32_t *zero);
 int Motion_get_axis_curr_step(uint8_t axis, int32_t *step);
 int Motion_get_axis_curr_vel(uint8_t axis, int32_t *vel);
-int Motion_set_axis_buffer(uint8_t axis, _Bool state);
+int Motion_set_axis_buffer(uint8_t axis, bool state);
 TYPE_MOTION_STATE Motion_get_axis_state(uint8_t axis);
 int Motion_get_pending_cmds(uint8_t *raState, uint8_t *decState);
 int Motion_set_axis_profile(uint8_t axis);
+int Motion_write_settings(void);
 double Motion_calc_axis_move_time(uint8_t axis, int32_t start, int32_t end);
 int Motion_wait_axis_buffer_clear(uint8_t axis);
 int Motion_move_axis_by_step(uint8_t axis, int32_t step);

--- a/src_servo/servo_write_settings.c
+++ b/src_servo/servo_write_settings.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "servo_std_defs.h"
+#include "servo_observ_cfg.h"
+#include "servo_motion_cfg.h"
+#include "servo_motion.h"
+#include "servo_mount_cfg.h"
+#include "servo_mount.h"
+
+int main(void)
+{
+int status = kSTATUS_OK; 
+
+Servo_init(kOBSERV_CFG_FILE, kMOUNT_CFG_FILE, kMOTION_CFG_FILE);
+
+printf("SERVO WRITE SETTING Utility - writes the current position and velocity PIDs \n");
+printf("USAGE ->  <No input agrs>\n");
+
+printf("\nSERVO WRITE SETTING Utility... writing current settings into the Roboclaw HW EEPROM.\n");
+
+// Just use the motor0 address, it the same for both RA and Dec
+status = Motion_write_settings();
+
+if (status == kSTATUS_OK)
+{
+	printf(">>> Settings write sucessful\n");
+}
+else
+{
+	printf("!!! SETTINGs WRITE FAILED!\n");
+}
+
+return 0;
+} // of main()
+


### PR DESCRIPTION
Fixed an uninitialized status variable in a new routine causing the E1013 error.  Added support for a new utility servo_write_settings that is needed to initially configure the Roboclaw controller, without using windows.  